### PR TITLE
[A1] Feature: `ps` 

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,4 @@
+CompileFlags:
+  # Assuming your editor opens at project_root/ and "kernel" is right there
+  Add:
+    -I..

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ mkfs
 kernel/kernel
 user/usys.S
 .gdbinit
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ UPROGS=\
 	$U/_grind\
 	$U/_wc\
 	$U/_zombie\
+	$U/_ps\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -105,3 +105,9 @@ struct proc {
   struct inode *cwd;           // Current directory
   char name[16];               // Process name (debugging)
 };
+
+struct uproc {
+  int pid;
+  int state; // should we change this to the enum: CONSIDER
+  char name[16];
+};

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -101,6 +101,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_ps(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +127,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_ps]      sys_ps,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_ps     22

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -96,30 +96,50 @@ sys_uptime(void)
 
 // report process status
 // list all porcess
-void
+uint64
 sys_ps(void)
 {
   static char *states[] = {
-  [UNUSED]   = "unused",
-  [USED]     = "used",
-  [SLEEPING] = "sleep ",
-  [RUNNABLE] = "runble",
-  [RUNNING]  = "run   ",
-  [ZOMBIE]   = "zombie"
-  };
+      [UNUSED] = "unused",
+      [USED] = "used",
+      [SLEEPING] = "sleep",
+      [RUNNABLE] = "runble",
+      [RUNNING] = "running",
+      [ZOMBIE] = "zombie"};
+
+  uint64 dst;
+  int max;
+  argaddr(0, &dst); // sys_call arg; the user-space pointer
+  argint(1, &max);  // sys_call arg; capacity of the array
+
   struct proc *p;
-  char *state;
+  struct uproc u;
+  int count = 0;
 
-  printf("PID\tState\tName\n");
-  for(p = proc; p < &proc[NPROC]; p++){
-    if(p->state == UNUSED)
+  for (p = proc; p < &proc[NPROC] && count < max; p++)
+  {
+    acquire(&p->lock);
+    if (p->state == UNUSED)
+    {
+      release(&p->lock);
       continue;
-    if(p->state >= 0 && p->state < NELEM(states) && states[p->state])
-      state = states[p->state];
-    else
-      state = "???";
-    printf("%d\t%s\t%s", p->pid, state, p->name);
-    printf("\n");
-  }
-}
+    }
 
+    if (p->state >= 0 && p->state < NELEM(states) && states[p->state])
+    {
+      u.pid = p->pid;
+      u.state = p->state;
+      safestrcpy(u.name, p->name, sizeof(u.name));
+      if (copyout(myproc()->pagetable, dst + count * sizeof(u), (char *)&u, sizeof(u)) < 0)
+      {
+        release(&p->lock);
+        return -1;
+      }
+      count++;
+    }
+
+    release(&p->lock);
+  }
+
+  return count;
+}

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -110,29 +110,29 @@ sys_ps(void)
 
   uint64 dst;
   int max;
-  argaddr(0, &dst); // sys_call arg; the user-space pointer
-  argint(1, &max);  // sys_call arg; capacity of the array
+  argaddr(0, &dst);  // sys_call arg; the user-space pointer
+  argint(1, &max);   // sys_call arg; capacity of the array
 
   struct proc *p;
   struct uproc u;
   int count = 0;
 
-  for (p = proc; p < &proc[NPROC] && count < max; p++)
-  {
+  // iterate all processes
+  for (p = proc; p < &proc[NPROC] && count < max; p++) {
     acquire(&p->lock);
-    if (p->state == UNUSED)
-    {
+    if (p->state == UNUSED) {
       release(&p->lock);
       continue;
     }
 
-    if (p->state >= 0 && p->state < NELEM(procstatenames) && procstatenames[p->state])
-    {
+    // copy the process info to user-space
+    if (p->state >= 0 && p->state < NELEM(procstatenames) &&
+        procstatenames[p->state]) {
       u.pid = p->pid;
       u.state = p->state;
       safestrcpy(u.name, p->name, sizeof(u.name));
-      if (copyout(myproc()->pagetable, dst + count * sizeof(u), (char *)&u, sizeof(u)) < 0)
-      {
+      if (copyout(myproc()->pagetable, dst + count * sizeof(u), (char *)&u,
+                  sizeof(u)) < 0) {
         release(&p->lock);
         return -1;
       }

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -6,6 +6,8 @@
 #include "spinlock.h"
 #include "proc.h"
 
+extern struct proc proc[NPROC];
+
 uint64
 sys_exit(void)
 {
@@ -91,3 +93,33 @@ sys_uptime(void)
   release(&tickslock);
   return xticks;
 }
+
+// report process status
+// list all porcess
+void
+sys_ps(void)
+{
+  static char *states[] = {
+  [UNUSED]   = "unused",
+  [USED]     = "used",
+  [SLEEPING] = "sleep ",
+  [RUNNABLE] = "runble",
+  [RUNNING]  = "run   ",
+  [ZOMBIE]   = "zombie"
+  };
+  struct proc *p;
+  char *state;
+
+  printf("PID\tState\tName\n");
+  for(p = proc; p < &proc[NPROC]; p++){
+    if(p->state == UNUSED)
+      continue;
+    if(p->state >= 0 && p->state < NELEM(states) && states[p->state])
+      state = states[p->state];
+    else
+      state = "???";
+    printf("%d\t%s\t%s", p->pid, state, p->name);
+    printf("\n");
+  }
+}
+

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -99,13 +99,14 @@ sys_uptime(void)
 uint64
 sys_ps(void)
 {
-  static char *states[] = {
-      [UNUSED] = "unused",
-      [USED] = "used",
-      [SLEEPING] = "sleep",
-      [RUNNABLE] = "runble",
-      [RUNNING] = "running",
-      [ZOMBIE] = "zombie"};
+  static  char *procstatenames[] = {
+    [UNUSED] = "unused",
+    [USED] = "used",
+    [SLEEPING] = "sleep",
+    [RUNNABLE] = "runble",
+    [RUNNING] = "running",
+    [ZOMBIE] = "zombie"
+  };
 
   uint64 dst;
   int max;
@@ -125,7 +126,7 @@ sys_ps(void)
       continue;
     }
 
-    if (p->state >= 0 && p->state < NELEM(states) && states[p->state])
+    if (p->state >= 0 && p->state < NELEM(procstatenames) && procstatenames[p->state])
     {
       u.pid = p->pid;
       u.state = p->state;

--- a/user/ps.c
+++ b/user/ps.c
@@ -19,23 +19,21 @@ static char *procstatenames[] = {
   [ZOMBIE] = "zombie"
 };
 
-static int
-parse_pids(char *str, int pids[], int max_count)
-{
+static int parse_pids(char *str, int pids[], int max_count) {
   int count = 0;
   char *p = str;
-  while (*p && count < max_count)
-  {
+  while (*p && count < max_count) {
     pids[count++] = atoi(p);
     char *comma = strchr(p, ',');
-    if (!comma)
-      break;
+    if (!comma) break;
     p = comma + 1;
   }
   return count;
 }
 
-int main(int argc, char *argv[])
+// ps: print all processes
+// ps [-p pidlist] [-o col1[,col2,...]]
+int main(int argc, char *argv[]) 
 {
   int pids[MAXPIDS];
   int pid_count = 0;
@@ -43,22 +41,18 @@ int main(int argc, char *argv[])
   char *columns[MAXCOLS];
   int num_cols = 0;
 
-  for (int i = 1; i < argc; i++)
-  {
-
-    if (strcmp(argv[i], "-p") == 0)
-    {
-      if (i + 1 >= argc)
-      {
+  // parse arguments
+  // -p pidlist
+  // -o col1[,col2,...]
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "-p") == 0) {
+      if (i + 1 >= argc) {
         printf("ps: missing argument after -p\n");
         exit(1);
       }
       pid_count = parse_pids(argv[++i], pids, MAXPIDS);
-    }
-    else if (strcmp(argv[i], "-o") == 0)
-    {
-      if (i + 1 >= argc)
-      {
+    } else if (strcmp(argv[i], "-o") == 0) {
+      if (i + 1 >= argc) {
         printf("ps: missing argument after -p\n");
         exit(1);
       }
@@ -66,32 +60,26 @@ int main(int argc, char *argv[])
       char *colstr = argv[++i];
       char *field = colstr;
 
-      while (num_cols < MAXCOLS && *field)
-      {
+      while (num_cols < MAXCOLS && *field) {
+        // Split the string by comma by replacing it with null terminator.
         char *comma = strchr(field, ',');
 
-        if (comma)
-        {
+        if (comma) {
           *comma = '\0';
           columns[num_cols++] = field;
           field = comma + 1;
-        }
-        else
-        {
+        } else {
           columns[num_cols++] = field;
           break;
         }
       }
-    }
-    else
-    {
+    } else {
       printf("Usage: ps [-p pidlist] [-o col1[,col2,...]]\n");
       exit(1);
     }
   }
 
-  if (num_cols == 0)
-  {
+  if (num_cols == 0) {
     columns[0] = "pid";
     columns[1] = "state";
     columns[2] = "name";
@@ -100,58 +88,45 @@ int main(int argc, char *argv[])
 
   struct uproc up[NPROC];
   int n = ps(up, NPROC);
-  if (n < 0)
-  {
+  if (n < 0) {
     printf("ps: error in sys_ps\n");
   }
 
   // print header
-  for (int i = 0; i < num_cols; i++)
-  {
+  for (int i = 0; i < num_cols; i++) {
     printf("%s\t", columns[i]);
   }
   printf("\n");
 
   // print process
-  for (int i = 0; i < n; i++)
-  {
-    if (pid_count > 0)
-    {
+  for (int i = 0; i < n; i++) {
+    if (pid_count > 0) {
       int match = 0;
-      for (int j = 0; j < pid_count; j++)
-      {
-        if (up[i].pid == pids[i])
-        {
+      for (int j = 0; j < pid_count; j++) {
+        if (up[i].pid == pids[i]) {
           match = 1;
           break;
         }
       }
 
-      if (!match)
-      {
+      if (!match) {
         continue;
       }
     }
 
     // Print each column in order.
-    for (int c = 0; c < num_cols; c++)
-    {
-      if (strcmp(columns[c], "pid") == 0)
-      {
+    for (int c = 0; c < num_cols; c++) {
+      if (strcmp(columns[c], "pid") == 0) {
         printf("%d\t", up[i].pid);
-      }
-      else if (strcmp(columns[c], "name") == 0)
-      {
+      } else if (strcmp(columns[c], "name") == 0) {
         printf("%s\t", up[i].name);
-      }
-      else if (strcmp(columns[c], "state") == 0)
-      {
+      } else if (strcmp(columns[c], "state") == 0) {
         int s = up[i].state;
-        char *st = (s >= 0 && s < NELEM(procstatenames) && procstatenames[s]) ? procstatenames[s] : "???";
+        char *st = (s >= 0 && s < NELEM(procstatenames) && procstatenames[s])
+                       ? procstatenames[s]
+                       : "???";
         printf("%s\t", st);
-      }
-      else
-      {
+      } else {
         printf("? \t");
       }
     }

--- a/user/ps.c
+++ b/user/ps.c
@@ -1,0 +1,11 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "kernel/fcntl.h"
+#include "user/user.h"
+
+int
+main(int argc, char *argv[])
+{
+  ps();
+  exit(0);
+}

--- a/user/ps.c
+++ b/user/ps.c
@@ -8,14 +8,15 @@
 #include "kernel/proc.h"
 
 #define MAXCOLS 5
+#define MAXPIDS 32
 
-static char *states[] = {
-  [0] = "UNUSED",
-  [1] = "USED",
-  [2] = "SLEEP",
-  [3] = "RUNBLE",
-  [4] = "RUN",
-  [5] = "ZOMBIE",
+static char *procstatenames[] = {
+  [UNUSED] = "unused",
+  [USED] = "used",
+  [SLEEPING] = "sleep",
+  [RUNNABLE] = "runble",
+  [RUNNING] = "running",
+  [ZOMBIE] = "zombie"
 };
 
 static int
@@ -23,112 +24,140 @@ parse_pids(char *str, int pids[], int max_count)
 {
   int count = 0;
   char *p = str;
-  while(*p && count < max_count){
+  while (*p && count < max_count)
+  {
     pids[count++] = atoi(p);
     char *comma = strchr(p, ',');
-    if(!comma)
+    if (!comma)
       break;
     p = comma + 1;
   }
   return count;
 }
 
-int
-main(int argc, char *argv[])
+int main(int argc, char *argv[])
 {
-  int pids[32];
+  int pids[MAXPIDS];
   int pid_count = 0;
 
   char *columns[MAXCOLS];
   int num_cols = 0;
 
-  for(int i = 1; i < argc; i++){
+  for (int i = 1; i < argc; i++)
+  {
 
-    if(strcmp(argv[i], "-p") == 0){
-      if(i + 1 >= argc){
+    if (strcmp(argv[i], "-p") == 0)
+    {
+      if (i + 1 >= argc)
+      {
         printf("ps: missing argument after -p\n");
         exit(1);
       }
-      pid_count = parse_pids(argv[++i], pids, 32);
-   } else if(strcmp(argv[i], "-o") == 0){
-      if(i + 1 >= argc){
+      pid_count = parse_pids(argv[++i], pids, MAXPIDS);
+    }
+    else if (strcmp(argv[i], "-o") == 0)
+    {
+      if (i + 1 >= argc)
+      {
         printf("ps: missing argument after -p\n");
         exit(1);
       }
-      
+
       char *colstr = argv[++i];
       char *field = colstr;
 
-      while (num_cols < MAXCOLS && *field){
-        char *comma = strchr(field, ','); 
+      while (num_cols < MAXCOLS && *field)
+      {
+        char *comma = strchr(field, ',');
 
-        if (comma){
+        if (comma)
+        {
           *comma = '\0';
           columns[num_cols++] = field;
           field = comma + 1;
-        } else {
+        }
+        else
+        {
           columns[num_cols++] = field;
           break;
         }
       }
-    } else {
+    }
+    else
+    {
       printf("Usage: ps [-p pidlist] [-o col1[,col2,...]]\n");
       exit(1);
-    } 
+    }
   }
 
-  if(num_cols == 0){
+  if (num_cols == 0)
+  {
     columns[0] = "pid";
     columns[1] = "state";
     columns[2] = "name";
     num_cols = 3;
   }
-  
-  struct uproc up[64];
-  int n = ps(up, 64);
-  if (n < 0){
+
+  struct uproc up[NPROC];
+  int n = ps(up, NPROC);
+  if (n < 0)
+  {
     printf("ps: error in sys_ps\n");
   }
-  
+
   // print header
-  for(int i = 0; i < num_cols; i++){
+  for (int i = 0; i < num_cols; i++)
+  {
     printf("%s\t", columns[i]);
   }
   printf("\n");
 
   // print process
-  for (int i = 0; i < n; i++){
-    if (pid_count > 0){
+  for (int i = 0; i < n; i++)
+  {
+    if (pid_count > 0)
+    {
       int match = 0;
-      for (int j = 0; j < pid_count; j++)  {
-        if(up[i].pid == pids[i]){
+      for (int j = 0; j < pid_count; j++)
+      {
+        if (up[i].pid == pids[i])
+        {
           match = 1;
           break;
         }
       }
 
-      if(!match){
-        continue; 
+      if (!match)
+      {
+        continue;
       }
     }
 
     // Print each column in order.
-    for(int c = 0; c < num_cols; c++){
-      if(strcmp(columns[c], "pid") == 0){
+    for (int c = 0; c < num_cols; c++)
+    {
+      if (strcmp(columns[c], "pid") == 0)
+      {
         printf("%d\t", up[i].pid);
-      } else if(strcmp(columns[c], "name") == 0){
+      }
+      else if (strcmp(columns[c], "name") == 0)
+      {
         printf("%s\t", up[i].name);
-      } else if(strcmp(columns[c], "state") == 0){
+      }
+      else if (strcmp(columns[c], "state") == 0)
+      {
         int s = up[i].state;
-        char *st = (s >= 0 && s < NELEM(states) && states[s]) ? states[s] : "???";
+        char *st = (s >= 0 && s < NELEM(procstatenames) && procstatenames[s]) ? procstatenames[s] : "???";
         printf("%s\t", st);
-      } else {
+      }
+      else
+      {
         printf("? \t");
       }
     }
 
     printf("\n");
   }
-  
+
   exit(0);
 }

--- a/user/ps.c
+++ b/user/ps.c
@@ -1,11 +1,134 @@
+#include "kernel/param.h"
 #include "kernel/types.h"
 #include "kernel/stat.h"
-#include "kernel/fcntl.h"
 #include "user/user.h"
+#include "kernel/fcntl.h"
+#include "kernel/spinlock.h"
+#include "kernel/riscv.h"
+#include "kernel/proc.h"
+
+#define MAXCOLS 5
+
+static char *states[] = {
+  [0] = "UNUSED",
+  [1] = "USED",
+  [2] = "SLEEP",
+  [3] = "RUNBLE",
+  [4] = "RUN",
+  [5] = "ZOMBIE",
+};
+
+static int
+parse_pids(char *str, int pids[], int max_count)
+{
+  int count = 0;
+  char *p = str;
+  while(*p && count < max_count){
+    pids[count++] = atoi(p);
+    char *comma = strchr(p, ',');
+    if(!comma)
+      break;
+    p = comma + 1;
+  }
+  return count;
+}
 
 int
 main(int argc, char *argv[])
 {
-  ps();
+  int pids[32];
+  int pid_count = 0;
+
+  char *columns[MAXCOLS];
+  int num_cols = 0;
+
+  for(int i = 1; i < argc; i++){
+
+    if(strcmp(argv[i], "-p") == 0){
+      if(i + 1 >= argc){
+        printf("ps: missing argument after -p\n");
+        exit(1);
+      }
+      pid_count = parse_pids(argv[++i], pids, 32);
+   } else if(strcmp(argv[i], "-o") == 0){
+      if(i + 1 >= argc){
+        printf("ps: missing argument after -p\n");
+        exit(1);
+      }
+      
+      char *colstr = argv[++i];
+      char *field = colstr;
+
+      while (num_cols < MAXCOLS && *field){
+        char *comma = strchr(field, ','); 
+
+        if (comma){
+          *comma = '\0';
+          columns[num_cols++] = field;
+          field = comma + 1;
+        } else {
+          columns[num_cols++] = field;
+          break;
+        }
+      }
+    } else {
+      printf("Usage: ps [-p pidlist] [-o col1[,col2,...]]\n");
+      exit(1);
+    } 
+  }
+
+  if(num_cols == 0){
+    columns[0] = "pid";
+    columns[1] = "state";
+    columns[2] = "name";
+    num_cols = 3;
+  }
+  
+  struct uproc up[64];
+  int n = ps(up, 64);
+  if (n < 0){
+    printf("ps: error in sys_ps\n");
+  }
+  
+  // print header
+  for(int i = 0; i < num_cols; i++){
+    printf("%s\t", columns[i]);
+  }
+  printf("\n");
+
+  // print process
+  for (int i = 0; i < n; i++){
+    if (pid_count > 0){
+      int match = 0;
+      for (int j = 0; j < pid_count; j++)  {
+        if(up[i].pid == pids[i]){
+          match = 1;
+          break;
+        }
+      }
+
+      if(!match){
+        continue; 
+      }
+    }
+
+    // Print each column in order.
+    for(int c = 0; c < num_cols; c++){
+      if(strcmp(columns[c], "pid") == 0){
+        printf("%d\t", up[i].pid);
+      } else if(strcmp(columns[c], "name") == 0){
+        printf("%s\t", up[i].name);
+      } else if(strcmp(columns[c], "state") == 0){
+        int s = up[i].state;
+        char *st = (s >= 0 && s < NELEM(states) && states[s]) ? states[s] : "???";
+        printf("%s\t", st);
+      } else {
+        printf("? \t");
+      }
+    }
+
+    printf("\n");
+  }
+  
   exit(0);
 }

--- a/user/user.h
+++ b/user/user.h
@@ -22,6 +22,7 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+int ps(void);
 
 // ulib.c
 int stat(const char*, struct stat*);

--- a/user/user.h
+++ b/user/user.h
@@ -1,4 +1,5 @@
 struct stat;
+struct uproc;
 
 // system calls
 int fork(void);
@@ -22,7 +23,7 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
-int ps(void);
+int ps(struct uproc*, int);
 
 // ulib.c
 int stat(const char*, struct stat*);
@@ -42,3 +43,5 @@ void *memcpy(void *, const void *, uint);
 // umalloc.c
 void* malloc(uint);
 void free(void*);
+
+#define NELEM(x) (sizeof(x)/sizeof((x)[0]))

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -36,3 +36,4 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("ps");


### PR DESCRIPTION
# New Feature: `ps`

Provide a process status view listing process IDs, names, and states.
[POSIX Spec](https://man7.org/linux/man-pages/man1/ps.1.html)

## Overview

The ps command in xv6 provides a snapshot of the currently running processes. This implementation is inspired by the POSIX ps utility but is simplified to match the limited functionality of xv6. It supports the following options:

    -p pidlist: Filters the output to display only the processes whose PIDs are in the comma-separated list.
    -o col1[,col2,...]: Specifies the columns (fields) to display. Available columns include:
        pid: Process ID
        state: Process state (one of unused, used, sleep, runble, running, zombie)
        name: Process name

If no options are provided, the command displays a default set of columns: pid, state, and name.

### Usage
`ps [ -p pidlist ] [ -o col1[,col2,...] ]`

### Options

-p pidlist
Specify a comma-separated list of process IDs to display. For example:

```sh
ps -p 1,2,10
```
This will display only the processes with PID 1, 2, or 10.

-o col1[,col2,...]
Specify the columns to display. For example:

```sh
ps -o pid,name
```
This will display only the pid and name columns. Valid column names include pid, state, and name.

### Examples

Display All Processes (Default Columns):

```sh
$ ps
pid     state     name
1       running   init
2       sleep     sh
3       sleep     ...
```

Filter by PID:
```sh
$ ps -p 1,2
pid     state     name
1       running   init
2       sleep     sh
```

Custom Output Columns:
```sh
$ ps -o pid,name
pid     name
1       init
2       sh
3       ...
```

<img width="249" alt="Screenshot 2025-02-12 at 1 30 35 PM" src="https://github.com/user-attachments/assets/8cddd791-1c31-4295-99c5-7e822651d76f" />

### Implementation Details

#### Kernel Side
The `sys_ps` system call is implemented in the kernel (in, for example, kernel/sysproc.c). It copies process information from the kernel's process table into a user-provided array of structures. The structure struct `uproc` contains the following fields:
```c
    struct uproc {
      int pid;
      int state;
      char name[16];
    };
```

Process Table Iteration:
The system call iterates over the process table (declared in kernel/proc.c as struct proc proc[NPROC]), locks each process entry, and for every active process (i.e., processes that are not UNUSED), copies the PID, state, and name into a temporary struct `uproc` variable, which is then copied out to user space.

#### User Side `ps.c`:
The user program located in user/ps.c calls the ps system call and processes its command-line arguments to implement filtering (-p) and output formatting (-o).