### PR TITLE
[A1] `ps`, `sleep`, `echo`, `mkdir` and `ls`

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,4 @@
+CompileFlags:
+  # Assuming your editor opens at project_root/ and "kernel" is right there
+  Add:
+    -I..

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ mkfs
 kernel/kernel
 user/usys.S
 .gdbinit
+.vscode/

--- a/Makefile
+++ b/Makefile
@@ -139,6 +139,7 @@ UPROGS=\
 	$U/_grind\
 	$U/_wc\
 	$U/_zombie\
+	$U/_ps\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ UPROGS=\
 	$U/_wc\
 	$U/_zombie\
 	$U/_ps\
+	$U/_sleep\
 
 fs.img: mkfs/mkfs README $(UPROGS)
 	mkfs/mkfs fs.img README $(UPROGS)

--- a/kernel/proc.h
+++ b/kernel/proc.h
@@ -105,3 +105,9 @@ struct proc {
   struct inode *cwd;           // Current directory
   char name[16];               // Process name (debugging)
 };
+
+struct uproc {
+  int pid;
+  int state; // should we change this to the enum: CONSIDER
+  char name[16];
+};

--- a/kernel/syscall.c
+++ b/kernel/syscall.c
@@ -101,6 +101,7 @@ extern uint64 sys_unlink(void);
 extern uint64 sys_link(void);
 extern uint64 sys_mkdir(void);
 extern uint64 sys_close(void);
+extern uint64 sys_ps(void);
 
 // An array mapping syscall numbers from syscall.h
 // to the function that handles the system call.
@@ -126,6 +127,7 @@ static uint64 (*syscalls[])(void) = {
 [SYS_link]    sys_link,
 [SYS_mkdir]   sys_mkdir,
 [SYS_close]   sys_close,
+[SYS_ps]      sys_ps,
 };
 
 void

--- a/kernel/syscall.h
+++ b/kernel/syscall.h
@@ -20,3 +20,4 @@
 #define SYS_link   19
 #define SYS_mkdir  20
 #define SYS_close  21
+#define SYS_ps     22

--- a/kernel/sysproc.c
+++ b/kernel/sysproc.c
@@ -6,6 +6,8 @@
 #include "spinlock.h"
 #include "proc.h"
 
+extern struct proc proc[NPROC];
+
 uint64
 sys_exit(void)
 {
@@ -90,4 +92,55 @@ sys_uptime(void)
   xticks = ticks;
   release(&tickslock);
   return xticks;
+}
+
+// report process status
+// list all porcess
+uint64
+sys_ps(void)
+{
+  static  char *procstatenames[] = {
+    [UNUSED] = "unused",
+    [USED] = "used",
+    [SLEEPING] = "sleep",
+    [RUNNABLE] = "runble",
+    [RUNNING] = "running",
+    [ZOMBIE] = "zombie"
+  };
+
+  uint64 dst;
+  int max;
+  argaddr(0, &dst);  // sys_call arg; the user-space pointer
+  argint(1, &max);   // sys_call arg; capacity of the array
+
+  struct proc *p;
+  struct uproc u;
+  int count = 0;
+
+  // iterate all processes
+  for (p = proc; p < &proc[NPROC] && count < max; p++) {
+    acquire(&p->lock);
+    if (p->state == UNUSED) {
+      release(&p->lock);
+      continue;
+    }
+
+    // copy the process info to user-space
+    if (p->state >= 0 && p->state < NELEM(procstatenames) &&
+        procstatenames[p->state]) {
+      u.pid = p->pid;
+      u.state = p->state;
+      safestrcpy(u.name, p->name, sizeof(u.name));
+      if (copyout(myproc()->pagetable, dst + count * sizeof(u), (char *)&u,
+                  sizeof(u)) < 0) {
+        release(&p->lock);
+        return -1;
+      }
+      count++;
+    }
+
+    release(&p->lock);
+  }
+
+  return count;
 }

--- a/user/echo.c
+++ b/user/echo.c
@@ -1,19 +1,70 @@
 #include "kernel/types.h"
 #include "kernel/stat.h"
+#include <stddef.h>
 #include "user/user.h"
+
+
+void echo_function_enhanced(int argc, char *argv[], int start_val){
+  for(int i = start_val; i < argc; i++){
+    int length_of_string = strlen(argv[i]);
+    for(int j = 0; j < length_of_string + 1; j++){
+      if(argv[i][j] == '\\'){
+        if(j + 1 != length_of_string) {
+          switch (argv[i][j + 1]) {
+              case 'n':
+                  write(1, "\n", 1);
+                  j++; 
+                  break;
+              case 't':
+                  write(1, "\t", 1);
+                  j++; 
+                  break;
+              //case '\\':
+                //write(1, "\\", 1);
+                //j++;
+                //break;
+              case 'e':
+                j = j + 3;
+              default:
+                  write(1, &argv[i][j], 1); // if \ just a part of the sentence, no escape sequences 
+                  break;
+          }
+        }
+      }
+      else {
+        write(1, &argv[i][j], 1); // input next character 
+      }
+    }
+    if (i + 1 < argc){
+      write(1, " ", 1); // put space between WORDS
+    }
+    else {
+      write(1, "\n", 1); // last character, so that next command can be inputted on next line 
+    }
+  }
+}
 
 int
 main(int argc, char *argv[])
 {
-  int i;
-
-  for(i = 1; i < argc; i++){
-    write(1, argv[i], strlen(argv[i]));
-    if(i + 1 < argc){
-      write(1, " ", 1);
-    } else {
-      write(1, "\n", 1);
+  int i; 
+  if(argc > 1){  
+    if(strcmp(argv[1], "-e") == 0){
+      echo_function_enhanced(argc, argv, 2);
+  }
+  else { 
+    // this is original code for echo 
+    for(i = 1; i < argc; i++){
+      write(1, argv[i], strlen(argv[i]));
+      if(i + 1 < argc){
+        write(1, " ", 1);
+    } 
+      else {
+        write(1, "\n", 1);
+      }
     }
   }
+}
+  
   exit(0);
 }

--- a/user/ls.c
+++ b/user/ls.c
@@ -4,84 +4,184 @@
 #include "kernel/fs.h"
 #include "kernel/fcntl.h"
 
-char*
-fmtname(char *path)
-{
-  static char buf[DIRSIZ+1];
+#define MAX_ENTRIES 100  // Limit to avoid excessive memory use
+
+int show_hidden = 0;        // **Flag for -a: Show hidden files**
+int append_symbols = 0;     // **Flag for -F: Append file type symbols**
+int long_format = 0;        // **Flag for -l: Long listing format**
+int stream_output = 0;      // **Flag for -m: Comma-separated output**
+
+// **Function to append symbols based on file type (-F flag implementation)**
+void append_file_symbol(char *name, short type) { 
+  switch (type) {
+    case T_DIR:
+      printf("%s/\n", name);
+      break;
+    case T_FILE:
+      printf("%s\n", name);
+      break;
+    case T_DEVICE:
+      printf("%s|\n", name);
+      break;
+    default:
+      printf("%s\n", name);
+  }
+}
+
+// **Function to extract the filename from a given path**
+char* fmtname(char *path) {
+  static char buf[DIRSIZ + 1];
   char *p;
 
-  // Find first character after last slash.
-  for(p=path+strlen(path); p >= path && *p != '/'; p--)
-    ;
+  // Find the last `/` in the path to extract the filename
+  for (p = path + strlen(path); p >= path && *p != '/'; p--);
   p++;
 
-  // Return blank-padded name.
-  if(strlen(p) >= DIRSIZ)
+  // **If -m flag is enabled, return the filename without padding**
+  if (stream_output) {  
+    return p;  
+  }
+
+  // Copy and pad the name with spaces for normal display
+  if (strlen(p) >= DIRSIZ)
     return p;
+
   memmove(buf, p, strlen(p));
-  memset(buf+strlen(p), ' ', DIRSIZ-strlen(p));
+  memset(buf + strlen(p), ' ', DIRSIZ - strlen(p));
+  buf[DIRSIZ] = '\0'; // Ensure null termination
   return buf;
 }
 
-void
-ls(char *path)
-{
+// **Function to list directory contents or display file information**
+void ls(char *path) {
   char buf[512], *p;
   int fd;
   struct dirent de;
   struct stat st;
+  int first_entry = 1; // **Used for formatting comma-separated output (-m flag)**
 
-  if((fd = open(path, O_RDONLY)) < 0){
+  if ((fd = open(path, O_RDONLY)) < 0) {
     fprintf(2, "ls: cannot open %s\n", path);
     return;
   }
 
-  if(fstat(fd, &st) < 0){
+  if (fstat(fd, &st) < 0) {
     fprintf(2, "ls: cannot stat %s\n", path);
     close(fd);
     return;
   }
 
-  switch(st.type){
+  switch (st.type) {
   case T_DEVICE:
   case T_FILE:
-    printf("%s %d %d %d\n", fmtname(path), st.type, st.ino, (int) st.size);
-    break;
+    if (stream_output) { // **-m flag: Print as a single entry**
+      printf("%s\n", fmtname(path));
+    } else if (long_format) { // **-l flag: Long format output**
+      char mode[11] = "----------";  // Dummy file mode for simplicity
+      mode[0] = (st.type == T_DIR) ? 'd' : '-';
+      
+      if (append_symbols) { // **Print POSIX-style long format with -l -F combo**
+        printf("%s %u ? ? %u ??? ", mode, 1, (uint)st.size);
+        append_file_symbol(fmtname(path), st.type);
+      } else { // **Print POSIX-style long format**
+        printf("%s %u ? ? %u ??? %s\n", mode, 1, (uint)st.size, fmtname(path));
+      }
+
+    } else if (append_symbols) { // **-F flag: Append file type symbols**
+      append_file_symbol(fmtname(path), st.type);
+    } else {
+      printf("%s %d %d %d\n", fmtname(path), st.type, st.ino, (int)st.size);
+    }
+    close(fd);
+    return;
 
   case T_DIR:
-    if(strlen(path) + 1 + DIRSIZ + 1 > sizeof buf){
+    if (strlen(path) + 1 + DIRSIZ + 1 > sizeof buf) {
       printf("ls: path too long\n");
       break;
     }
+
     strcpy(buf, path);
-    p = buf+strlen(buf);
+    p = buf + strlen(buf);
     *p++ = '/';
-    while(read(fd, &de, sizeof(de)) == sizeof(de)){
-      if(de.inum == 0)
+
+    while (read(fd, &de, sizeof(de)) == sizeof(de)) {
+      if (de.inum == 0)
         continue;
+
+      if (!show_hidden && de.name[0] == '.') { 
+        continue; // **-a flag: Skip hidden files unless enabled**
+      }
+
       memmove(p, de.name, DIRSIZ);
       p[DIRSIZ] = 0;
-      if(stat(buf, &st) < 0){
+
+      if (stat(buf, &st) < 0) {
         printf("ls: cannot stat %s\n", buf);
         continue;
       }
-      printf("%s %d %d %d\n", fmtname(buf), st.type, st.ino, (int) st.size);
+
+      if (stream_output) { // **-m flag: Format as comma-separated list**
+        if (!first_entry) {
+          printf(", "); // **Add comma before entries except the first one**
+        }
+        printf("%s", fmtname(buf));
+        first_entry = 0; // **Mark that at least one entry has been printed**
+      } else if (long_format) { // **-l flag: Long format output**
+        char mode[11] = "----------";  
+        mode[0] = (st.type == T_DIR) ? 'd' : '-';
+
+        if (append_symbols) { // **Print POSIX-style long format with -l -F combo**
+          printf("%s %u ? ? %u ??? ", mode, 1, (uint)st.size);
+          append_file_symbol(fmtname(buf), st.type);
+        } else { // **Print POSIX-style long format**
+          printf("%s %u ? ? %u ??? %s\n", mode, 1, (uint)st.size, fmtname(buf));
+        }
+
+      } else if (append_symbols) { // **-F flag: Append file type symbols**
+        append_file_symbol(fmtname(buf), st.type);
+      } else {
+        printf("%s %d %d %d\n", fmtname(buf), st.type, st.ino, (int)st.size);
+      }
+    }
+
+    if (stream_output) { // **-m flag: End output with a newline**
+      printf("\n");
     }
     break;
   }
   close(fd);
 }
 
-int
-main(int argc, char *argv[])
-{
-  int i;
+// **Main function to parse flags and list files/directories**
+int main(int argc, char *argv[]) {
+  int i = 1;
 
-  if(argc < 2){
-    ls(".");
-    exit(0);
+  // **Parse flags**
+  for (; i < argc; i++) {
+    if (argv[i][0] == '-') {
+      for (int j = 1; argv[i][j] != '\0'; j++) {
+        if (argv[i][j] == 'a') show_hidden = 1; // **Enable -a flag**
+        else if (argv[i][j] == 'F') append_symbols = 1; // **Enable -F flag**
+        else if (argv[i][j] == 'l' && stream_output == 0) long_format = 1; // **Enable -l flag**
+        else if (argv[i][j] == 'm') { // **Enable -m flag**
+          stream_output = 1;
+          long_format = 0; // **-m flag disables -l flag**
+        }
+      }
+    } else {
+      break; // finish with flag mode setup, move on to the ls operation
+    }
   }
-  for(i=1; i<argc; i++)
-    ls(argv[i]);
+
+  // **If no directory is specified, list the current directory**
+  if (i == argc) {
+    ls(".");
+  } else {
+    for (; i < argc; i++) {
+      ls(argv[i]);
+    }
+  }
+
   exit(0);
 }

--- a/user/mkdir.c
+++ b/user/mkdir.c
@@ -1,21 +1,76 @@
 #include "kernel/types.h"
 #include "kernel/stat.h"
+#include "Kernel/fcntl.h"
 #include "user/user.h"
 
-int
-main(int argc, char *argv[])
+int makeDirectory (char *path){
+  char *p;
+  char temp;
+  int status = 0;
+
+  // Skip leading slashes
+  p = path;
+  while (*p == '/')
+    p++;
+
+  while (*p != 0) {
+    // Find the next component
+    while (*p != '/' && *p != 0)
+      p++;
+
+    temp = *p;
+    *p = 0; // Temporarily clear string value
+
+    if (mkdir(path) < 0) {
+      // Atempt to open the directory
+      int fd = open(path, O_RDONLY); // fd = file descriptor
+      if (fd > 0) {
+        fprintf(2, "mkdir: cannot create directory '%s'\n", path);
+        status = -1;
+        break;
+      }
+      close(fd);
+    }
+
+    *p = temp; // Restore string value
+    if (temp == 0)
+      break;
+
+    while (*p == '/') // Ignore consecutive slashes
+      p++;
+  }
+
+  return status;
+}
+
+int main(int argc, char *argv[])
 {
   int i;
+  int parentFlag = 0;
 
-  if(argc < 2){
+  if (argc < 2) {
     fprintf(2, "Usage: mkdir files...\n");
     exit(1);
   }
 
-  for(i = 1; i < argc; i++){
-    if(mkdir(argv[i]) < 0){
-      fprintf(2, "mkdir: %s failed to create\n", argv[i]);
-      break;
+  // Checks number of arguments when parent flag is present
+  if (strcmp(argv[1], "-p") == 0) {
+    parentFlag = 1;
+    if (argc < 3) {
+      fprintf(2, "Not enough arguments");
+      exit(1);
+    }
+  }
+
+  for (i = 1 + parentFlag; i < argc; i++) {
+    if (parentFlag) {
+      if (makeDirectory(argv[i]) < 0)
+        exit(1);
+    } else {
+      if (makeDirectory(argv[i]) < 0) {
+        fprintf(2, "mkdir: %s failed to create\n", argv[i]);
+        exit(1);
+      }
     }
   }
 

--- a/user/ps.c
+++ b/user/ps.c
@@ -1,0 +1,138 @@
+#include "kernel/param.h"
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+#include "kernel/fcntl.h"
+#include "kernel/spinlock.h"
+#include "kernel/riscv.h"
+#include "kernel/proc.h"
+
+#define MAXCOLS 5
+#define MAXPIDS 32
+
+static char *procstatenames[] = {
+  [UNUSED] = "unused",
+  [USED] = "used",
+  [SLEEPING] = "sleep",
+  [RUNNABLE] = "runble",
+  [RUNNING] = "running",
+  [ZOMBIE] = "zombie"
+};
+
+static int parse_pids(char *str, int pids[], int max_count) {
+  int count = 0;
+  char *p = str;
+  while (*p && count < max_count) {
+    pids[count++] = atoi(p);
+    char *comma = strchr(p, ',');
+    if (!comma) break;
+    p = comma + 1;
+  }
+  return count;
+}
+
+// ps: print all processes
+// ps [-p pidlist] [-o col1[,col2,...]]
+int main(int argc, char *argv[]) 
+{
+  int pids[MAXPIDS];
+  int pid_count = 0;
+
+  char *columns[MAXCOLS];
+  int num_cols = 0;
+
+  // parse arguments
+  // -p pidlist
+  // -o col1[,col2,...]
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "-p") == 0) {
+      if (i + 1 >= argc) {
+        printf("ps: missing argument after -p\n");
+        exit(1);
+      }
+      pid_count = parse_pids(argv[++i], pids, MAXPIDS);
+    } else if (strcmp(argv[i], "-o") == 0) {
+      if (i + 1 >= argc) {
+        printf("ps: missing argument after -p\n");
+        exit(1);
+      }
+
+      char *colstr = argv[++i];
+      char *field = colstr;
+
+      while (num_cols < MAXCOLS && *field) {
+        // Split the string by comma by replacing it with null terminator.
+        char *comma = strchr(field, ',');
+
+        if (comma) {
+          *comma = '\0';
+          columns[num_cols++] = field;
+          field = comma + 1;
+        } else {
+          columns[num_cols++] = field;
+          break;
+        }
+      }
+    } else {
+      printf("Usage: ps [-p pidlist] [-o col1[,col2,...]]\n");
+      exit(1);
+    }
+  }
+
+  if (num_cols == 0) {
+    columns[0] = "pid";
+    columns[1] = "state";
+    columns[2] = "name";
+    num_cols = 3;
+  }
+
+  struct uproc up[NPROC];
+  int n = ps(up, NPROC);
+  if (n < 0) {
+    printf("ps: error in sys_ps\n");
+  }
+
+  // print header
+  for (int i = 0; i < num_cols; i++) {
+    printf("%s\t", columns[i]);
+  }
+  printf("\n");
+
+  // print process
+  for (int i = 0; i < n; i++) {
+    if (pid_count > 0) {
+      int match = 0;
+      for (int j = 0; j < pid_count; j++) {
+        if (up[i].pid == pids[i]) {
+          match = 1;
+          break;
+        }
+      }
+
+      if (!match) {
+        continue;
+      }
+    }
+
+    // Print each column in order.
+    for (int c = 0; c < num_cols; c++) {
+      if (strcmp(columns[c], "pid") == 0) {
+        printf("%d\t", up[i].pid);
+      } else if (strcmp(columns[c], "name") == 0) {
+        printf("%s\t", up[i].name);
+      } else if (strcmp(columns[c], "state") == 0) {
+        int s = up[i].state;
+        char *st = (s >= 0 && s < NELEM(procstatenames) && procstatenames[s])
+                       ? procstatenames[s]
+                       : "???";
+        printf("%s\t", st);
+      } else {
+        printf("? \t");
+      }
+    }
+
+    printf("\n");
+  }
+
+  exit(0);
+}

--- a/user/sleep.c
+++ b/user/sleep.c
@@ -1,0 +1,63 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+
+void print_help() {
+	fprintf(1, "Usage: sleep <TICKS>\n");
+	fprintf(1, "       sleep OPTION\n");
+	fprintf(1, "Pause for number of TICKS.\n");
+	fprintf(1, "TICKS must be an integer or is interpreted as integer if it is float.\n");
+	fprintf(1, "Given two or more arguments, pause for the amount of time specified by\n");
+	fprintf(1, "the sum of their values.\n");
+	fprintf(1, "--help\n");
+	fprintf(1, "display help and exit\n");
+	fprintf(1, "--version\n");
+	fprintf(1, "display version number\n");
+	exit(0);
+}
+
+void print_version() {
+	fprintf(1, "Version 1.0\n");
+	exit(0);
+}
+
+int is_positive_int(const char *s) {
+	// Check negative
+	if (*s == '-') return 0;
+	// Check non-digit
+	for (; *s; s++) {
+		if (*s < '0' || *s > '9') return 0;
+	}
+	return 1;
+}
+
+int main(int argc, char *argv[]) {
+	// Sleep requires at least 2 arguments 
+	// with the first being sleep itself and the second being the sleep ticks
+	if(argc < 2){
+		fprintf(2, "missing operand. Usage: sleep <ticks>\n");
+		exit(1);
+	}
+        
+	// Check for help or version command
+	if (strcmp(argv[1], "--help") == 0) print_help();
+        else if (strcmp(argv[1], "--version") == 0) print_version();
+        
+
+	// If there are multiple tick arguments, they are added together
+	int total_ticks = 0;
+	for (int i = 1; i<argc; i++) {
+		if (!is_positive_int(argv[i])) {
+			fprintf(2, "sleep: invalid ticks '%s'\n", argv[i]);
+			exit(1);
+		}
+		total_ticks += atoi(argv[i]);
+	}
+	
+	// Sleep for total_ticks amount of time
+	if (sleep(total_ticks) < 0) { // sys_sleep return -1 if failed
+		fprintf(2, "Sleep failed\n");
+		exit(1);
+	}
+	exit(0);
+}

--- a/user/user.h
+++ b/user/user.h
@@ -1,4 +1,5 @@
 struct stat;
+struct uproc;
 
 // system calls
 int fork(void);
@@ -22,6 +23,7 @@ int getpid(void);
 char* sbrk(int);
 int sleep(int);
 int uptime(void);
+int ps(struct uproc*, int);
 
 // ulib.c
 int stat(const char*, struct stat*);
@@ -41,3 +43,5 @@ void *memcpy(void *, const void *, uint);
 // umalloc.c
 void* malloc(uint);
 void free(void*);
+
+#define NELEM(x) (sizeof(x)/sizeof((x)[0]))

--- a/user/usys.pl
+++ b/user/usys.pl
@@ -36,3 +36,4 @@ entry("getpid");
 entry("sbrk");
 entry("sleep");
 entry("uptime");
+entry("ps");


### PR DESCRIPTION
# Assignment 1
> Each Individual Features/Enhancements are squashed in single commit/PR look below:

<details>
  <summary>Feature: `ps`</summary>

# New Feature: `ps`

Provide a process status view listing process IDs, names, and states.
[POSIX Spec](https://man7.org/linux/man-pages/man1/ps.1.html)

## Overview

The ps command in xv6 provides a snapshot of the currently running processes. This implementation is inspired by the POSIX ps utility but is simplified to match the limited functionality of xv6. It supports the following options:

    -p pidlist: Filters the output to display only the processes whose PIDs are in the comma-separated list.
    -o col1[,col2,...]: Specifies the columns (fields) to display. Available columns include:
        pid: Process ID
        state: Process state (one of unused, used, sleep, runble, running, zombie)
        name: Process name

If no options are provided, the command displays a default set of columns: pid, state, and name.

### Usage
`ps [ -p pidlist ] [ -o col1[,col2,...] ]`

### Options

-p pidlist
Specify a comma-separated list of process IDs to display. For example:

```sh
ps -p 1,2,10
```
This will display only the processes with PID 1, 2, or 10.

-o col1[,col2,...]
Specify the columns to display. For example:

```sh
ps -o pid,name
```
This will display only the pid and name columns. Valid column names include pid, state, and name.

### Examples

Display All Processes (Default Columns):

```sh
$ ps
pid     state     name
1       running   init
2       sleep     sh
3       sleep     ...
```

Filter by PID:
```sh
$ ps -p 1,2
pid     state     name
1       running   init
2       sleep     sh
```

Custom Output Columns:
```sh
$ ps -o pid,name
pid     name
1       init
2       sh
3       ...
```

<img width="249" alt="Screenshot 2025-02-12 at 1 30 35 PM" src="https://github.com/user-attachments/assets/8cddd791-1c31-4295-99c5-7e822651d76f" />

### Implementation Details

#### Kernel Side
The `sys_ps` system call is implemented in the kernel (in, for example, kernel/sysproc.c). It copies process information from the kernel's process table into a user-provided array of structures. The structure struct `uproc` contains the following fields:
```c
    struct uproc {
      int pid;
      int state;
      char name[16];
    };
```

Process Table Iteration:
The system call iterates over the process table (declared in kernel/proc.c as struct proc proc[NPROC]), locks each process entry, and for every active process (i.e., processes that are not UNUSED), copies the PID, state, and name into a temporary struct `uproc` variable, which is then copied out to user space.

#### User Side `ps.c`:
The user program located in user/ps.c calls the ps system call and processes its command-line arguments to implement filtering (-p) and output formatting (-o).

</details>

<details>
  <summary>Feature: `sleep`</summary>

# New Feature:  `sleep`
Pauses for a user-specified number of ticks.
[POSIX spec](https://pubs.opengroup.org/onlinepubs/9799919799/) 
[Linux Man Page](https://linux.die.net/man/1/sleep)

## Overview
The sleep utility in xv6 provides the ability to pause for a number of ticks. A tick in xv6 is an arbitrary time interval defined by the xv6 kernel based on the time between 2 interrupts on the hardware time chip. Here tick is always interpreted as an integer due to the underlying tick-based time implementation of xv6. Because of the `atoi` implementation, the decimal places of float inputs are dropped. Given two or more arguments, pause for the amount of time specified by the sum of their values. Negative and non-digit values will result in exit with error message.
![image](https://github.com/user-attachments/assets/22c60cb0-d32e-4838-9b7f-d51ac17c37f7)

## Usage
`sleep ticks...`
`sleep [OPTION]`

## Options
--help
        display the help and exit
```
$ sleep --help
```
--version
        display the version number and exit
```
$ sleep --version
```
## Examples
### Missing input argument:
```
$ sleep
missing operand. Usage: sleep <ticks>
```
### sleep for 10 ticks:
```
$ sleep 10
```
### sleep with multiple arguments:
```
$ sleep 1 2 3
```
sleep 1 2 3 equals to sleep 6. 1+2+3 = 6

### sleep with invalid inputs:
Negative value:
```
$ sleep -1
sleep: invalid ticks '-1'
$ sleep 1 2 -3
sleep: invalid ticks '-3'
```
![image](https://github.com/user-attachments/assets/f136a8c2-c6ce-4e66-a34b-5660a5e633f7)

Non-digit:
```
$ sleep a
sleep: invalid ticks 'a'
$ sleep 1 2 3 a 4
sleep: invalid ticks 'a'
```
![image](https://github.com/user-attachments/assets/60df9837-626e-47d6-bef9-3111700abc6c)

### sleep with options:
--help:
```
$ sleep --help
Usage: sleep <TICKS>
       sleep OPTION
Pause for number of TICKS.
TICKS must be an integer or is interpreted as integer if it is float.
Given two or more arguments, pause for the amount of time specified by
the sum of their values.
--help
display help and exit
--version
display version number
```
--version:
```
$ sleep --version
Version 1.0
```
## Implementation Details
### Kernal Side
None
### User Side *sleep.c*
Function for input type validation:
```
int is_positive_int(const char *s) {
        // Check negative
        if (*s == '-') return 0;
        // Check non-digit
        for (; *s; s++) {
                if (*s < '0' || *s > '9') return 0;
        }
        return 1;
}
```
Code for help and version argument detection:
```
if (strcmp(argv[1], "--help") == 0) print_help();
else if (strcmp(argv[1], "--version") == 0) print_version();
```
Code for input length validation:
```
if(argc < 2){
        fprintf(2, "missing operand. Usage: sleep <ticks>\n");
        exit(1); 
}
```
Code for calculating total sleep time for multi-arguments:
```
int total_ticks = 0;
for (int i = 1; i<argc; i++) {
        if (!is_positive_int(argv[i])) {
                fprintf(2, "sleep: invalid ticks '%s'\n", argv[i]);
                exit(1);
        }
        total_ticks += atoi(argv[i]);
}
```

## Edge Cases
When inputting both OPTIONs, only the first option will be taken as input. This is the same as the Linux implementation.
```
$ sleep --version --help
Version 1.0
$ sleep --help --version
Usage: sleep <TICKS>
       sleep OPTION
Pause for number of TICKS.
TICKS must be an integer or is interpreted as integer if it is float.
Given two or more arguments, pause for the amount of time specified by
the sum of their values.
--help
display help and exit
--version
display version number
```
![image](https://github.com/user-attachments/assets/a9c453c6-1c9a-43b8-a9d0-931248a32f67)

When there are multiple invalid tick arguments, only the first one will be included in the error message.
```
$ sleep -1 -2 -3 1
sleep: invalid ticks '-1'
$ sleep a b c
sleep: invalid ticks 'a'
```
![image](https://github.com/user-attachments/assets/84acd8f8-5f09-4c79-a4f6-67021e69eaea)

</details>


<details>
  <summary>Enhancement: `ls`</summary>

# Enhancement: `ls`
## Introduction
[POSIX Spec](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ls.html)

This document details the implementation of additional POSIX-compliant features in the `ls` command for xv6-riscv. The new features include:
- `-a`: Show hidden files
- `-F`: Append file type symbols
- `-l`: Display long format listing
- `-m`: Output entries in a comma-separated format

Each section below outlines the implementation, accompanied by relevant code snippets and test cases.

---

## Implemented Features and Code Changes

### 1. `-a` (Show Hidden Files)
#### **Implementation**
By default, files starting with `.` are hidden. The flag `-a` allows these files to be listed.

**Modified `ls` function:**
```c
if (!show_hidden && de.name[0] == '.') {
    continue; // Skip hidden files unless -a is enabled
}
```
**Flag Parsing in `main()`:**
```c
else if (argv[i][j] == 'a') show_hidden = 1; // Enable -a flag
```
**Test Cases:**
-  `ls` → Should exclude hidden files
-  `ls -a` → Should include hidden files like `.bashrc`
-  `ls -a /some/directory` → Should list hidden and normal files

---

### 2. `-F` (Append File Type Symbols)
#### **Implementation**
Appends file type indicators: `/` for directories, `|` for devices.

**Function to append symbols:**
```c
void append_file_symbol(char *name, short type) {
    switch (type) {
        case T_DIR:
            printf("%s/\n", name);
            break;
        case T_FILE:
            printf("%s\n", name);
            break;
        case T_DEVICE:
            printf("%s|\n", name);
            break;
        default:
            printf("%s\n", name);
    }
}
```
**Flag Parsing in `main()`:**
```c
else if (argv[i][j] == 'F') append_symbols = 1; // Enable -F flag
```
**Test Cases:**
-  `ls -F` → Should display directories with `/`, devices with `|`
-  `ls -a -F` → Should show hidden files with appropriate type symbols

---

### 3. `-l` (Long Listing Format)
#### **Implementation**
Displays detailed file metadata in a format similar to POSIX. This is a simplified version without the "Group", "Owner", and "Date and Time" fields. 

**Modified `ls` function:**
```c
if (long_format) {
    char mode[11] = "----------"; // Dummy file mode
    mode[0] = (st.type == T_DIR) ? 'd' : '-';
    printf("%s %u ? ? %u ??? %s\n", mode, 1, (uint)st.size, fmtname(buf));
}
```
**Flag Parsing in `main()`:**
```c
else if (argv[i][j] == 'l' && stream_output == 0) long_format = 1; // Enable -l flag
```
**Test Cases:**
-  `ls -l` → Should display file permissions, size, and name
-  `ls -l -a` → Should list hidden files with metadata
-  `ls -l -F` → Should show file details along with type indicators

---

### 4. `-m` (Comma-Separated Output)
#### **Implementation**
Prints entries in a single line, separated by commas.

**Modified `ls` function:**
```c
if (stream_output) { // -m flag: Format as comma-separated list
    if (!first_entry) {
        printf(", "); // Add comma before entries except the first one
    }
    printf("%s", fmtname(buf));
    first_entry = 0; // Mark that at least one entry has been printed
}
```
**Flag Parsing in `main()`:**
```c
else if (argv[i][j] == 'm') {
    stream_output = 1;
    long_format = 0; // -m flag disables -l flag
}
```
**Test Cases:**
-  `ls -m` → Should print files in a single line, comma-separated
-  `ls -m -a` → Should include hidden files in the comma-separated list

---

## Edge Cases and Misuse Handling
### **Invalid Combinations**
- `ls -m -l`: The `-m` flag disables `-l`, and the implementation ensures that the output format is adjusted accordingly.
- `ls -F -m`: Ensures that type indicators are appended while maintaining comma separation.

### **Long Paths and Memory Constraints**
- **Handled Path Length:** Ensures paths do not exceed buffer limits to prevent crashes.
- **Memory Efficiency:** Limits directory entries processed to `MAX_ENTRIES = 100`.

</details>

<details>
  <summary>Enhancement: `echo`</summary>

# Enhancement: `echo`

Enhance xv6's  `echo` feature  to support escape sequences `\t`, `\n` and `\e`
[POSIX Spec](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/echo.html)
# Overview 

This implementation is inspired by the POSIX standard. A new flag is added, `-e` that when used, allows characters such as `\t`, `\n` and `\e` to be escaped. 

# Usage & Examples
`echo -e _[string]_` OR `echo _string`_

To escape characters use:
`echo -e hi\nmy\nname is noura`

which would output: 
hi
my
name is noura

To NOT escape characters use: 
`echo hi my name is noura'

which outputs: 
hi my name is noura

# Implementation Details 
Developed on top of the existing echo command in for the user in file echo.c. 
If the `e` flag is included within the command, i.e. `argv[2] equals -e`, then we iterate through every character of the string and write each character of the string out to the stdout. If the character is a `\` following by a `t`, `e` or `n` , i.e escape character, write the corresponding escape character out to stdin then skip the next iteration of the loop. 

If the `e` flag is not included within the command, then continue with the original implementation of `echo` provided by xv6.

View an example below: 

<img width="793" alt="Screenshot 2025-02-13 at 7 56 01 PM" src="https://github.com/user-attachments/assets/1d9e08ec-9483-41cd-80a4-757c0967bf3e" />

</details>

<details>
  <summary>Enhancement: `mkdir`</summary>

# Enhancement: `mkdir`
Expand xv6's `mkdir` to support the parent flag `-p`, which creates any missing intermediate pathname components.
[POSIX Spec](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/mkdir.html)

# Overview
The `mkdir` command in xv6 was only able to create a directory within the user's current directory. 
The addition of the `-p` flag allows for multiple nested directories to be created with one `mkdir` command. For each operand that does not name an existing directory, they will be created in the order and hierarchy specified.
The implementation is inspired by the POSIX `mkdir` command, but simplified for use within xv6.

# Usage & Examples
Create the new directory `a`:
`mkdir a`
```
root
    | --> a
```

Create the new directories `a`, `b` and `c`:
`mkdir a b c`
```
root
    | --> a
    | --> b
    | --> c
```

Create the new directory `b` inside the new directory `a`:
`mkdir -p a/b`
```
root
    | --> a
           | --> b
```

Create the new directory `b` inside the new directory `a` and then create the new directory `c`:
`mkdir -p a/b`
```
root
    | --> a
    |      | --> b
    |
    | --> c
```

Create the new directory `b` inside the new directory `a` and then create the new directory `d` inside the new directory `c`:
`mkdir -p a/b c/d`
```
root
    | --> a
    |      | --> b
    |
    | --> c
           | --> d
    
```

# Implementation Details
`parentFlag` is used to track when the `-p` flag is present. If the flag is present, the code then checks if the correct number of arguments are present:
```
int main(int argc, char *argv[])
{
  int i;
  int parentFlag = 0; 
  ...

 if (strcmp(argv[1], "-p") == 0) {
    parentFlag = 1;
    if (argc < 3) {
      fprintf(2, "Not enough arguments");
      exit(1);
    }
  }
```

The `makeDirectory()` function is called from `main`:
```
  for (i = 1 + parentFlag; i < argc; i++) {
    if (parentFlag) {
      if (makeDirectory(argv[i]) < 0)
        exit(1);
    } else {
      if (makeDirectory(argv[i]) < 0) {
        fprintf(2, "mkdir: %s failed to create\n", argv[i]);
        exit(1);
      }
    }
  }
```
the `makeDirectory()` function utilizes a system call for `mkdir`:
```
int makeDirectory (char *path){
    ...

    if (mkdir(path) < 0) {
      // Atempt to open the directory
      int fd = open(path, O_RDONLY); // fd = file descriptor
      if (fd > 0) {
        fprintf(2, "mkdir: cannot create directory '%s'\n", path);
        status = -1;
        break;
      }
      close(fd);
    }
```
</details>