### PR TITLE
[A1] Enhance: `mkdir`

### DIFF
--- a/user/mkdir.c
+++ b/user/mkdir.c
@@ -74,5 +74,5 @@ int main(int argc, char *argv[])
     }
   }
 
-  exit(1);
+  exit(0);
 }

--- a/user/mkdir.c
+++ b/user/mkdir.c
@@ -1,23 +1,78 @@
 #include "kernel/types.h"
 #include "kernel/stat.h"
+#include "Kernel/fcntl.h"
 #include "user/user.h"
 
-int
-main(int argc, char *argv[])
+int makeDirectory (char *path){
+  char *p;
+  char temp;
+  int status = 0;
+
+  // Skip leading slashes
+  p = path;
+  while (*p == '/')
+    p++;
+
+  while (*p != 0) {
+    // Find the next component
+    while (*p != '/' && *p != 0)
+      p++;
+
+    temp = *p;
+    *p = 0; // Temporarily clear string value
+
+    if (mkdir(path) < 0) {
+      // Atempt to open the directory
+      int fd = open(path, O_RDONLY); // fd = file descriptor
+      if (fd > 0) {
+        fprintf(2, "mkdir: cannot create directory '%s'\n", path);
+        status = -1;
+        break;
+      }
+      close(fd);
+    }
+
+    *p = temp; // Restore string value
+    if (temp == 0)
+      break;
+
+    while (*p == '/') // Ignore consecutive slashes
+      p++;
+  }
+
+  return status;
+}
+
+int main(int argc, char *argv[])
 {
   int i;
+  int parentFlag = 0;
 
-  if(argc < 2){
+  if (argc < 2) {
     fprintf(2, "Usage: mkdir files...\n");
     exit(1);
   }
 
-  for(i = 1; i < argc; i++){
-    if(mkdir(argv[i]) < 0){
-      fprintf(2, "mkdir: %s failed to create\n", argv[i]);
-      break;
+  // Checks number of arguments when parent flag is present
+  if (strcmp(argv[1], "-p") == 0) {
+    parentFlag = 1;
+    if (argc < 3) {
+      fprintf(2, "Not enough arguments");
+      exit(1);
     }
   }
 
-  exit(0);
+  for (i = 1 + parentFlag; i < argc; i++) {
+    if (parentFlag) {
+      if (makeDirectory(argv[i]) < 0)
+        exit(1);
+    } else {
+      if (makeDirectory(argv[i]) < 0) {
+        fprintf(2, "mkdir: %s failed to create\n", argv[i]);
+        exit(1);
+      }
+    }
+  }
+
+  exit(1);
 }


### PR DESCRIPTION
# Feature Enhancement: `mkdir`
Expand xv6's `mkdir` to support the parent flag `-p`, which creates any missing intermediate pathname components.
[POSIX Spec](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/mkdir.html)

# Overview
The `mkdir` command in xv6 was only able to create a directory within the user's current directory. 
The addition of the `-p` flag allows for multiple nested directories to be created with one `mkdir` command. For each operand that does not name an existing directory, they will be created in the order and hierarchy specified.
The implementation is inspired by the POSIX `mkdir` command, but simplified for use within xv6.

# Usage & Examples
Create the new directory `a`:
`mkdir a`
```
root
    | --> a
```

Create the new directories `a`, `b` and `c`:
`mkdir a b c`
```
root
    | --> a
    | --> b
    | --> c
```

Create the new directory `b` inside the new directory `a`:
`mkdir -p a/b`
```
root
    | --> a
           | --> b
```

Create the new directory `b` inside the new directory `a` and then create the new directory `c`:
`mkdir -p a/b`
```
root
    | --> a
    |      | --> b
    |
    | --> c
```

Create the new directory `b` inside the new directory `a` and then create the new directory `d` inside the new directory `c`:
`mkdir -p a/b c/d`
```
root
    | --> a
    |      | --> b
    |
    | --> c
           | --> d
    
```

# Implementation Details
`parentFlag` is used to track when the `-p` flag is present. If the flag is present, the code then checks if the correct number of arguments are present:
```
int main(int argc, char *argv[])
{
  int i;
  int parentFlag = 0; 
  ...

 if (strcmp(argv[1], "-p") == 0) {
    parentFlag = 1;
    if (argc < 3) {
      fprintf(2, "Not enough arguments");
      exit(1);
    }
  }
```

The `makeDirectory()` function is called from `main`:
```
  for (i = 1 + parentFlag; i < argc; i++) {
    if (parentFlag) {
      if (makeDirectory(argv[i]) < 0)
        exit(1);
    } else {
      if (makeDirectory(argv[i]) < 0) {
        fprintf(2, "mkdir: %s failed to create\n", argv[i]);
        exit(1);
      }
    }
  }
```
the `makeDirectory()` function utilizes a system call for `mkdir`:
```
int makeDirectory (char *path){
    ...

    if (mkdir(path) < 0) {
      // Atempt to open the directory
      int fd = open(path, O_RDONLY); // fd = file descriptor
      if (fd > 0) {
        fprintf(2, "mkdir: cannot create directory '%s'\n", path);
        status = -1;
        break;
      }
      close(fd);
    }
```