### PR TITLE
[A3.1] Demand Paging

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,4 @@
+CompileFlags:
+  # Assuming your editor opens at project_root/ and "kernel" is right there
+  Add:
+    -I..

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ UPROGS=\
 	$U/_usertests\
 	$U/_grind\
 	$U/_wc\
+	$U/_dptest\
 	$U/_zombie\
 
 fs.img: mkfs/mkfs README $(UPROGS)

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -39,6 +39,7 @@ void            fsinit(int);
 int             dirlink(struct inode*, char*, uint);
 struct inode*   dirlookup(struct inode*, char*, uint*);
 struct inode*   ialloc(uint, short);
+struct inode *iget(uint dev, uint inum);
 struct inode*   idup(struct inode*);
 void            iinit();
 void            ilock(struct inode*);

--- a/kernel/defs.h
+++ b/kernel/defs.h
@@ -174,6 +174,7 @@ uint64          walkaddr(pagetable_t, uint64);
 int             copyout(pagetable_t, uint64, char *, uint64);
 int             copyin(pagetable_t, char *, uint64, uint64);
 int             copyinstr(pagetable_t, char *, uint64, uint64);
+int             handledemandp(pagetable_t pagetable, uint64 va);
 
 // plic.c
 void            plicinit(void);

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -47,19 +47,7 @@ exec(char *path, char **argv)
     goto bad;
   
   printf("Loading file: %s, inode number: %d\n", path, ip->inum);
-  // printf("type: %d\n", elf.type);
-  // printf("machine: %d\n", elf.machine);
-  // printf("version: %d\n", elf.version);
-  // printf("entry: %lx\n", elf.entry);
-  // printf("phoff: %lx\n", elf.phoff);
-  // printf("shoff: %lx\n", elf.shoff);
-  // printf("flags: %d\n", elf.flags);
-  // printf("ehsize: %d\n", elf.ehsize);
-  // printf("phentsize: %d\n", elf.phentsize);
   printf("phnum: %d\n", elf.phnum);
-  // printf("shentsize: %d\n", elf.shentsize);
-  // printf("shnum: %d\n", elf.shnum);
-  // printf("shstrndx: %d\n", elf.shstrndx);
 
   if(elf.magic != ELF_MAGIC)
     goto bad;
@@ -71,15 +59,6 @@ exec(char *path, char **argv)
   for(i=0, off=elf.phoff; i<elf.phnum; i++, off+=sizeof(ph)){
     if(readi(ip, 0, (uint64)&ph, off, sizeof(ph)) != sizeof(ph))
       goto bad;
-    
-    // printf("------\n");
-    // printf("Vaddr: %lx\n", ph.vaddr);
-    // printf("Type: %d\n", ph.type);
-    // printf("Off: %lx\n", ph.off);
-    // printf("Filesz: %ld\n", ph.filesz);
-    // printf("Memsz: %ld\n", ph.memsz);
-    // printf("Flags: %d\n", ph.flags);
-    // printf("Align: %lx\n", ph.align);
     
     if(ph.type != ELF_PROG_LOAD)
       continue;
@@ -226,12 +205,7 @@ loadseg(pagetable_t pagetable, uint64 va, struct inode *ip, uint offset, uint sz
         return -1;
       }
     } else {
-      // For demand paging, we should store:
-      // 1. File offset
-      // 2. Size to read
-      // 3. inode number (for reopening)
-      
-      // Create metadata: pack file info into 64 bits
+      // Demand Paging metadata: pack file info into 64 bits
       // Format: [inum(16bits)][size(16bits)][offset(32bits)]
       uint64 metadata = ((uint64)ip->inum << 48) | ((uint64)n << 32) | (offset + i);
       printf("Demand Paging with the virtual address: %lx and metadata: %lx\n", va + i, metadata);

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -151,6 +151,7 @@ loadseg(pagetable_t pagetable, uint64 va, struct inode *ip, uint offset, uint sz
   uint64 pa;
 
   for(i = 0; i < sz; i += PGSIZE){
+    printf("Loading page at VA 0x%lx from file offset 0x%x, size %d\n", va + i, offset + i, PGSIZE);
     pa = walkaddr(pagetable, va + i);
     if(pa == 0)
       panic("loadseg: address should exist");

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -69,15 +69,18 @@ exec(char *path, char **argv)
     if(ph.vaddr % PGSIZE != 0)
       goto bad;
     
+    // Calculate required memory
     uint64 new_sz = PGROUNDUP(ph.vaddr + ph.memsz);
     if (new_sz > sz){
       sz = new_sz;
     }
     
+    // Attempt to load segment into memory; handle errors on failure
     if (loadseg(pagetable, ph.vaddr, ip, ph.off, ph.filesz) < 0) {
       goto bad;
     } 
     
+    // Set up page table entries for BSS (Block Started by Symbol)
     if (ph.memsz > 0 && ph.filesz == 0) {
       uint64 bss_start = ph.vaddr + ph.filesz; // Start of .bss
       uint64 bss_size = ph.memsz - ph.filesz;  // Size of .bss
@@ -185,6 +188,7 @@ loadseg(pagetable_t pagetable, uint64 va, struct inode *ip, uint offset, uint sz
 
     printf("Loading page at VA 0x%lx from file offset 0x%x, size %d\n", va + i, offset + i, n);
    
+    // Determine if the page of memory is "essential" for immediate execution.
     int is_essential = ((va + i) >= TEXTBASE && (va + i) < TEXTBASE + TEXTSIZE) || 
                        ((va + i) >= USTACKTOP - PGSIZE && (va + i) < USTACKTOP);
 

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -124,12 +124,12 @@ exec(char *path, char **argv)
   // Make the first inaccessible as a stack guard.
   // Use the rest as the user stack.
   sz = PGROUNDUP(sz);
-  printf("\nSize: %ld\n", sz);
+  printf("Size: %ld\n", sz);
   uint64 sz1;
   if((sz1 = uvmalloc(pagetable, sz, sz + (USERSTACK+1)*PGSIZE, PTE_W)) == 0)
     goto bad;
   sz = sz1;
-  printf("\nStack Size: %ld\n", sz);
+  printf("Stack Size: %ld\n", sz);
   uvmclear(pagetable, sz-(USERSTACK+1)*PGSIZE);
   sp = sz;
   stackbase = sp - USERSTACK*PGSIZE;

--- a/kernel/exec.c
+++ b/kernel/exec.c
@@ -6,6 +6,9 @@
 #include "proc.h"
 #include "defs.h"
 #include "elf.h"
+#include "sleeplock.h"
+#include "fs.h"
+#include "file.h"
 
 static int loadseg(pde_t *, uint64, struct inode *, uint, uint);
 
@@ -42,6 +45,21 @@ exec(char *path, char **argv)
   // Check ELF header
   if(readi(ip, 0, (uint64)&elf, 0, sizeof(elf)) != sizeof(elf))
     goto bad;
+  
+  printf("Loading file: %s, inode number: %d\n", path, ip->inum);
+  // printf("type: %d\n", elf.type);
+  // printf("machine: %d\n", elf.machine);
+  // printf("version: %d\n", elf.version);
+  // printf("entry: %lx\n", elf.entry);
+  // printf("phoff: %lx\n", elf.phoff);
+  // printf("shoff: %lx\n", elf.shoff);
+  // printf("flags: %d\n", elf.flags);
+  // printf("ehsize: %d\n", elf.ehsize);
+  // printf("phentsize: %d\n", elf.phentsize);
+  printf("phnum: %d\n", elf.phnum);
+  // printf("shentsize: %d\n", elf.shentsize);
+  // printf("shnum: %d\n", elf.shnum);
+  // printf("shstrndx: %d\n", elf.shstrndx);
 
   if(elf.magic != ELF_MAGIC)
     goto bad;
@@ -53,6 +71,16 @@ exec(char *path, char **argv)
   for(i=0, off=elf.phoff; i<elf.phnum; i++, off+=sizeof(ph)){
     if(readi(ip, 0, (uint64)&ph, off, sizeof(ph)) != sizeof(ph))
       goto bad;
+    
+    // printf("------\n");
+    // printf("Vaddr: %lx\n", ph.vaddr);
+    // printf("Type: %d\n", ph.type);
+    // printf("Off: %lx\n", ph.off);
+    // printf("Filesz: %ld\n", ph.filesz);
+    // printf("Memsz: %ld\n", ph.memsz);
+    // printf("Flags: %d\n", ph.flags);
+    // printf("Align: %lx\n", ph.align);
+    
     if(ph.type != ELF_PROG_LOAD)
       continue;
     if(ph.memsz < ph.filesz)
@@ -61,13 +89,30 @@ exec(char *path, char **argv)
       goto bad;
     if(ph.vaddr % PGSIZE != 0)
       goto bad;
-    uint64 sz1;
-    if((sz1 = uvmalloc(pagetable, sz, ph.vaddr + ph.memsz, flags2perm(ph.flags))) == 0)
+    
+    uint64 new_sz = PGROUNDUP(ph.vaddr + ph.memsz);
+    if (new_sz > sz){
+      sz = new_sz;
+    }
+    
+    if (loadseg(pagetable, ph.vaddr, ip, ph.off, ph.filesz) < 0) {
       goto bad;
-    sz = sz1;
-    if(loadseg(pagetable, ph.vaddr, ip, ph.off, ph.filesz) < 0)
-      goto bad;
+    } 
+    
+    if (ph.memsz > 0 && ph.filesz == 0) {
+      uint64 bss_start = ph.vaddr + ph.filesz; // Start of .bss
+      uint64 bss_size = ph.memsz - ph.filesz;  // Size of .bss
+      printf("Marking .bss from VA 0x%lx to 0x%lx for demand paging\n", bss_start, bss_start + bss_size);
+  
+      // Mark each page in the .bss range as demand-paged
+      for (uint64 va = PGROUNDDOWN(bss_start); va < PGROUNDUP(bss_start + bss_size); va += PGSIZE) {
+        if (mappages(pagetable, va, PGSIZE, 0, PTE_U | PTE_D) != 0) { // Mark as demand-paged, no physical page yet
+          goto bad;
+        }
+      }
+    }
   }
+
   iunlockput(ip);
   end_op();
   ip = 0;
@@ -79,10 +124,12 @@ exec(char *path, char **argv)
   // Make the first inaccessible as a stack guard.
   // Use the rest as the user stack.
   sz = PGROUNDUP(sz);
+  printf("\nSize: %ld\n", sz);
   uint64 sz1;
   if((sz1 = uvmalloc(pagetable, sz, sz + (USERSTACK+1)*PGSIZE, PTE_W)) == 0)
     goto bad;
   sz = sz1;
+  printf("\nStack Size: %ld\n", sz);
   uvmclear(pagetable, sz-(USERSTACK+1)*PGSIZE);
   sp = sz;
   stackbase = sp - USERSTACK*PGSIZE;
@@ -151,16 +198,49 @@ loadseg(pagetable_t pagetable, uint64 va, struct inode *ip, uint offset, uint sz
   uint64 pa;
 
   for(i = 0; i < sz; i += PGSIZE){
-    printf("Loading page at VA 0x%lx from file offset 0x%x, size %d\n", va + i, offset + i, PGSIZE);
-    pa = walkaddr(pagetable, va + i);
-    if(pa == 0)
-      panic("loadseg: address should exist");
+    // Calculate how many bytes to load - might be less than PGSIZE at the end
     if(sz - i < PGSIZE)
       n = sz - i;
     else
       n = PGSIZE;
-    if(readi(ip, 0, (uint64)pa, offset+i, n) != n)
-      return -1;
+
+    printf("Loading page at VA 0x%lx from file offset 0x%x, size %d\n", va + i, offset + i, n);
+   
+    int is_essential = ((va + i) >= TEXTBASE && (va + i) < TEXTBASE + TEXTSIZE) || 
+                       ((va + i) >= USTACKTOP - PGSIZE && (va + i) < USTACKTOP);
+
+    if (is_essential) {
+      printf("Loading Eagerly at VA 0x%lx\n", va + i);
+      // Load eagerly (current behavior)
+      pa = (uint64)kalloc();
+      if (pa == 0)
+        return -1;
+      memset((void *)pa, 0, PGSIZE);
+     
+      if (readi(ip, 0, (uint64)pa, offset + i, n) != n) {
+        kfree((void *)pa);
+        return -1;
+      }
+      if (mappages(pagetable, va + i, PGSIZE, pa, PTE_R | PTE_X | PTE_U | PTE_W) != 0) {
+        kfree((void *)pa);
+        return -1;
+      }
+    } else {
+      // For demand paging, we should store:
+      // 1. File offset
+      // 2. Size to read
+      // 3. inode number (for reopening)
+      
+      // Create metadata: pack file info into 64 bits
+      // Format: [inum(16bits)][size(16bits)][offset(32bits)]
+      uint64 metadata = ((uint64)ip->inum << 48) | ((uint64)n << 32) | (offset + i);
+      printf("Demand Paging with the virtual address: %lx and metadata: %lx\n", va + i, metadata);
+      
+      // Mark as demand-paged (use PTE_D flag but no PTE_V)
+      if (mappages(pagetable, va + i, PGSIZE, metadata, PTE_U | PTE_D) != 0) {
+        return -1;
+      }
+    }
   }
   
   return 0;

--- a/kernel/fs.c
+++ b/kernel/fs.c
@@ -189,7 +189,7 @@ iinit()
   }
 }
 
-static struct inode* iget(uint dev, uint inum);
+struct inode* iget(uint dev, uint inum);
 
 // Allocate an inode on device dev.
 // Mark it as allocated by  giving it type type.
@@ -243,7 +243,7 @@ iupdate(struct inode *ip)
 // Find the inode with number inum on device dev
 // and return the in-memory copy. Does not lock
 // the inode and does not read it from disk.
-static struct inode*
+struct inode*
 iget(uint dev, uint inum)
 {
   struct inode *ip, *empty;

--- a/kernel/memlayout.h
+++ b/kernel/memlayout.h
@@ -38,6 +38,9 @@
 // from physical address 0x80000000 to PHYSTOP.
 #define KERNBASE 0x80000000L
 #define PHYSTOP (KERNBASE + 128*1024*1024)
+#define TEXTBASE      0x1000        // Start of text segment
+#define TEXTSIZE      0x100000      // Size of text segment (1MB)
+#define USTACKTOP     TRAPFRAME     // Top of
 
 // map the trampoline page to the highest address,
 // in both user and kernel space.

--- a/kernel/riscv.h
+++ b/kernel/riscv.h
@@ -362,6 +362,7 @@ typedef uint64 *pagetable_t; // 512 PTEs
 #define PTE_W (1L << 2)
 #define PTE_X (1L << 3)
 #define PTE_U (1L << 4) // user can access
+#define PTE_D (1L << 8) // demand-page
 
 // shift a physical address to the right place for a PTE.
 #define PA2PTE(pa) ((((uint64)pa) >> 12) << 10)

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -82,92 +82,14 @@ usertrap(void)
       setkilled(p);
       goto end_trap;
     }
-    
-    // See if this is a page marked for demand paging
-    pte_t *pte = walk(p->pagetable, page_aligned_va, 0);
-    if(pte == 0) {
-      printf("usertrap(): page not found in page table %lx\n", va);
-      printf("            sepc=%lx pid=%d\n", r_sepc(), p->pid);
-      setkilled(p);
-      goto end_trap;
-    }
-    
-    printf("pte=%lx pte_flags=%lx\n", *pte, PTE_FLAGS(*pte));
-    
-    // Check if this is a demand-paged entry (PTE_D flag set but PTE_V not set)
-    if((*pte & PTE_D) && !(*pte & PTE_V)) {
-      void *pa = kalloc();
-      if(pa == 0) {
-        printf("usertrap(): kalloc failed for demand paging\n");
-        setkilled(p);
-        goto end_trap;
-      }
-      
-      memset(pa, 0, PGSIZE);
-      
-      uint64 metadata = *pte & ~0xFFF; // Remove flags
-      
-      if(metadata == 0) {
-         // For .bss, we just need to map the zeroed page
-         int perm = PTE_FLAGS(*pte) & ~PTE_D; 
-         perm |= PTE_V | PTE_W | PTE_R; 
-         *pte = PA2PTE((uint64)pa) | perm | PTE_U;
-         
-         printf("Zero-initialized page loaded at address %lx\n", page_aligned_va);
-      } else {
-        uint16 inum = metadata >> 48;
-        uint16 size = (metadata >> 32) & 0xFFFF;
-        uint32 offset = metadata & 0xFFFFFFFF;
-        
-        // Retrieve file permissions stored in the PTE
-        int perm = PTE_FLAGS(*pte) & ~PTE_D; // Remove demand flag
-        perm |= PTE_V | PTE_R | PTE_X; // Mark as valid, readable, executable
-        
-        // Load the page from disk
-        begin_op();
-        struct inode *ip = iget(ROOTDEV, inum);
-        if(ip == 0) {
-          kfree(pa);
-          end_op();
-          printf("usertrap(): failed to open inode %d\n", inum);
-          setkilled(p);
-          goto end_trap;
-        }
-        
-        ilock(ip);
-        
-        // Read the file data into the page
-        if(readi(ip, 0, (uint64)pa, offset, size) != size) {
-          kfree(pa);
-          iunlockput(ip);
-          end_op();
-          printf("usertrap(): failed to read file data\n");
-          setkilled(p);
-          goto end_trap;
-        }
-        
-        iunlockput(ip);
-        end_op();
-        
-        // Update the page table entry with the new physical page
-        *pte = PA2PTE((uint64)pa) | perm | PTE_U;
-        
-        // Done - when we return, the process will retry the access
-        printf("Demand-paged address %lx loaded from file (inode=%d offset=0x%x size=%d)\n", 
-               page_aligned_va, inum, offset, size); 
-      }
-      
-    } else {
+
+    // Try to handle as a demand-paged fault
+    if (handledemandp(p->pagetable, page_aligned_va) == -1) {
       // Not a demand-paged entry or some other kind of page fault
       printf("usertrap(): unexpected page fault at %lx\n", va);
-      printf("            scause=%ld sepc=%ld pid=%d\n", r_scause(), r_sepc(), p->pid);
-      printf("            pte=%lx pte_flags=%lx\n", *pte, PTE_FLAGS(*pte));
+      printf("            scause=%ld sepc=%ld pid=%d\n", r_scause(), r_sepc(),p->pid);
       setkilled(p);
     }
-  } else {
-    printf("usertrap(): unexpected scause 0x%ld pid=%d\n", r_scause(), p->pid);
-    printf("            sepc=0x%lx stval=0x%lx\n", r_sepc(), r_stval());
-    setkilled(p);
   }
 
 end_trap:

--- a/kernel/trap.c
+++ b/kernel/trap.c
@@ -5,9 +5,12 @@
 #include "spinlock.h"
 #include "proc.h"
 #include "defs.h"
+#include "fs.h"
 
 struct spinlock tickslock;
 uint ticks;
+
+extern struct inode *iget(uint dev, uint inum);
 
 extern char trampoline[], uservec[], userret[];
 
@@ -67,12 +70,107 @@ usertrap(void)
     syscall();
   } else if((which_dev = devintr()) != 0){
     // ok
+  } else if(r_scause() == 12 || r_scause() == 13 || r_scause() == 15) {
+    uint64 va = r_stval(); // Get the faulting virtual address
+    uint64 page_aligned_va = PGROUNDDOWN(va);
+    printf("Page fault at virtual address %lx\n", page_aligned_va);
+    
+    // Check if the address is valid
+    if(va >= p->sz) {
+      printf("usertrap(): invalid virtual address %lx\n", va);
+      printf("            sepc=%lx pid=%d sz=%ld\n", r_sepc(), p->pid, p->sz);
+      setkilled(p);
+      goto end_trap;
+    }
+    
+    // See if this is a page marked for demand paging
+    pte_t *pte = walk(p->pagetable, page_aligned_va, 0);
+    if(pte == 0) {
+      printf("usertrap(): page not found in page table %lx\n", va);
+      printf("            sepc=%lx pid=%d\n", r_sepc(), p->pid);
+      setkilled(p);
+      goto end_trap;
+    }
+    
+    printf("pte=%lx pte_flags=%lx\n", *pte, PTE_FLAGS(*pte));
+    
+    // Check if this is a demand-paged entry (PTE_D flag set but PTE_V not set)
+    if((*pte & PTE_D) && !(*pte & PTE_V)) {
+      void *pa = kalloc();
+      if(pa == 0) {
+        printf("usertrap(): kalloc failed for demand paging\n");
+        setkilled(p);
+        goto end_trap;
+      }
+      
+      memset(pa, 0, PGSIZE);
+      
+      uint64 metadata = *pte & ~0xFFF; // Remove flags
+      
+      if(metadata == 0) {
+         // For .bss, we just need to map the zeroed page
+         int perm = PTE_FLAGS(*pte) & ~PTE_D; 
+         perm |= PTE_V | PTE_W | PTE_R; 
+         *pte = PA2PTE((uint64)pa) | perm | PTE_U;
+         
+         printf("Zero-initialized page loaded at address %lx\n", page_aligned_va);
+      } else {
+        uint16 inum = metadata >> 48;
+        uint16 size = (metadata >> 32) & 0xFFFF;
+        uint32 offset = metadata & 0xFFFFFFFF;
+        
+        // Retrieve file permissions stored in the PTE
+        int perm = PTE_FLAGS(*pte) & ~PTE_D; // Remove demand flag
+        perm |= PTE_V | PTE_R | PTE_X; // Mark as valid, readable, executable
+        
+        // Load the page from disk
+        begin_op();
+        struct inode *ip = iget(ROOTDEV, inum);
+        if(ip == 0) {
+          kfree(pa);
+          end_op();
+          printf("usertrap(): failed to open inode %d\n", inum);
+          setkilled(p);
+          goto end_trap;
+        }
+        
+        ilock(ip);
+        
+        // Read the file data into the page
+        if(readi(ip, 0, (uint64)pa, offset, size) != size) {
+          kfree(pa);
+          iunlockput(ip);
+          end_op();
+          printf("usertrap(): failed to read file data\n");
+          setkilled(p);
+          goto end_trap;
+        }
+        
+        iunlockput(ip);
+        end_op();
+        
+        // Update the page table entry with the new physical page
+        *pte = PA2PTE((uint64)pa) | perm | PTE_U;
+        
+        // Done - when we return, the process will retry the access
+        printf("Demand-paged address %lx loaded from file (inode=%d offset=0x%x size=%d)\n", 
+               page_aligned_va, inum, offset, size); 
+      }
+      
+    } else {
+      // Not a demand-paged entry or some other kind of page fault
+      printf("usertrap(): unexpected page fault at %lx\n", va);
+      printf("            scause=%ld sepc=%ld pid=%d\n", r_scause(), r_sepc(), p->pid);
+      printf("            pte=%lx pte_flags=%lx\n", *pte, PTE_FLAGS(*pte));
+      setkilled(p);
+    }
   } else {
-    printf("usertrap(): unexpected scause 0x%lx pid=%d\n", r_scause(), p->pid);
+    printf("usertrap(): unexpected scause 0x%ld pid=%d\n", r_scause(), p->pid);
     printf("            sepc=0x%lx stval=0x%lx\n", r_sepc(), r_stval());
     setkilled(p);
   }
 
+end_trap:
   if(killed(p))
     exit(-1);
 

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -162,7 +162,13 @@ mappages(pagetable_t pagetable, uint64 va, uint64 size, uint64 pa, int perm)
       return -1;
     if(*pte & PTE_V)
       panic("mappages: remap");
-    *pte = PA2PTE(pa) | perm | PTE_V;
+
+    if (perm & PTE_D) {  // Demand-paged page
+      *pte = pa | perm; // Store file offset in pa, set demand-paged flag
+    } else {
+      *pte = PA2PTE(pa) | perm | PTE_V; // Normal mapping (eager load)
+    }
+
     if(a == last)
       break;
     a += PGSIZE;
@@ -186,13 +192,15 @@ uvmunmap(pagetable_t pagetable, uint64 va, uint64 npages, int do_free)
   for(a = va; a < va + npages*PGSIZE; a += PGSIZE){
     if((pte = walk(pagetable, a, 0)) == 0)
       panic("uvmunmap: walk");
-    if((*pte & PTE_V) == 0)
+    if((*pte & PTE_V) == 0 && (*pte & PTE_D) == 0)
       panic("uvmunmap: not mapped");
     if(PTE_FLAGS(*pte) == PTE_V)
       panic("uvmunmap: not a leaf");
     if(do_free){
-      uint64 pa = PTE2PA(*pte);
-      kfree((void*)pa);
+      if (*pte & PTE_V) {
+        uint64 pa = PTE2PA(*pte);
+        kfree((void*)pa);
+      }
     }
     *pte = 0;
   }
@@ -320,6 +328,17 @@ uvmcopy(pagetable_t old, pagetable_t new, uint64 sz)
   for(i = 0; i < sz; i += PGSIZE){
     if((pte = walk(old, i, 0)) == 0)
       panic("uvmcopy: pte should exist");
+    
+    // Handle demand-paged entries
+    if((*pte & PTE_V) == 0 && (*pte & PTE_D)) {
+      // This is a demand-paged entry - copy as is
+      uint64 metadata = *pte & ~0xFFF; // Save the metadata
+      flags = PTE_FLAGS(*pte);
+      if(mappages(new, i, PGSIZE, metadata, flags) != 0)
+        goto err;
+      continue; // Skip the normal page handling
+    }
+    
     if((*pte & PTE_V) == 0)
       panic("uvmcopy: page not present");
     pa = PTE2PA(*pte);

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -384,10 +384,16 @@ copyout(pagetable_t pagetable, uint64 dstva, char *src, uint64 len)
     va0 = PGROUNDDOWN(dstva);
     if(va0 >= MAXVA)
       return -1;
+    // Try to handle demand paging if needed
+    if(handledemandp(pagetable, va0) != 0) {
+      // Not demand-paged or failed to load, check validity normally
+      pte = walk(pagetable, va0, 0);
+      if(pte == 0 || (*pte & PTE_V) == 0 || (*pte & PTE_U) == 0 || (*pte & PTE_W) == 0)
+        return -1;
+    }
+    
+    // Get the physical address (which now should be valid)
     pte = walk(pagetable, va0, 0);
-    if(pte == 0 || (*pte & PTE_V) == 0 || (*pte & PTE_U) == 0 ||
-       (*pte & PTE_W) == 0)
-      return -1;
     pa0 = PTE2PA(*pte);
     n = PGSIZE - (dstva - va0);
     if(n > len)
@@ -467,4 +473,71 @@ copyinstr(pagetable_t pagetable, char *dst, uint64 srcva, uint64 max)
   } else {
     return -1;
   }
+}
+
+int
+handledemandp(pagetable_t pagetable, uint64 va)
+{
+  pte_t *pte = walk(pagetable, va, 0);
+  if(pte == 0)
+    return -1;
+    
+  if((*pte & PTE_D) && !(*pte & PTE_V)) {
+    void *pa = kalloc();
+    if(pa == 0)
+      return -1;
+      
+    memset(pa, 0, PGSIZE);
+    
+    uint64 metadata = *pte & ~0xFFF; // Remove flags
+    
+    if(metadata == 0) {
+      // For .bss, we just need to map the zeroed page
+      int perm = PTE_FLAGS(*pte) & ~PTE_D; 
+      perm |= PTE_V | PTE_W | PTE_R; 
+      *pte = PA2PTE((uint64)pa) | perm | PTE_U;
+      
+      printf("Zero-initialized page loaded at address %lx\n", va);
+    } else {
+      uint16 inum = metadata >> 48;
+      uint16 size = (metadata >> 32) & 0xFFFF;
+      uint32 offset = metadata & 0xFFFFFFFF;
+      
+      // Retrieve file permissions stored in the PTE
+      int perm = PTE_FLAGS(*pte) & ~PTE_D; // Remove demand flag
+      perm |= PTE_V | PTE_R | PTE_X | PTE_W;
+      
+      // Load the page from disk
+      begin_op();
+      struct inode *ip = iget(ROOTDEV, inum);
+      if(ip == 0) {
+        kfree(pa);
+        end_op();
+        printf("handle_demand_page(): failed to open inode %d\n", inum);
+        return -1;
+      }
+      
+      ilock(ip);
+      
+      // Read the file data into the page
+      if(readi(ip, 0, (uint64)pa, offset, size) != size) {
+        kfree(pa);
+        iunlockput(ip);
+        end_op();
+        printf("handle_demand_page(): failed to read file data\n");
+        return -1;
+      }
+      
+      iunlockput(ip);
+      end_op();
+      
+      *pte = PA2PTE((uint64)pa) | perm | PTE_U;
+      
+      printf("Demand-paged address %lx loaded from file (inode=%d offset=0x%x size=%d)\n", va, inum, offset, size); 
+    }
+    
+    return 0;
+  }
+  
+  return -1;
 }

--- a/kernel/vm.c
+++ b/kernel/vm.c
@@ -189,6 +189,7 @@ uvmunmap(pagetable_t pagetable, uint64 va, uint64 npages, int do_free)
   if((va % PGSIZE) != 0)
     panic("uvmunmap: not aligned");
 
+  // Pull mappings from page table
   for(a = va; a < va + npages*PGSIZE; a += PGSIZE){
     if((pte = walk(pagetable, a, 0)) == 0)
       panic("uvmunmap: walk");
@@ -475,6 +476,9 @@ copyinstr(pagetable_t pagetable, char *dst, uint64 srcva, uint64 max)
   }
 }
 
+// Handle demand paging for a virtual addres va
+// If va is makred for demand paging then physical memory will be allocated,
+// then the page content is loaded and the page table entry is updated.
 int
 handledemandp(pagetable_t pagetable, uint64 va)
 {

--- a/user/dptest.c
+++ b/user/dptest.c
@@ -1,0 +1,106 @@
+#include "kernel/types.h"
+#include "kernel/stat.h"
+#include "user/user.h"
+
+// Define a large array that should trigger demand paging
+#define ARRAY_SIZE (4*1024*1024)  // 4MB of data
+char large_array[ARRAY_SIZE];
+
+void test_sequential_access() {
+  printf("Testing sequential memory access...\n");
+  
+  // Access each page of the array sequentially
+  // This should trigger demand paging one page at a time
+  for (int i = 0; i < ARRAY_SIZE; i += 4096) {
+    large_array[i] = i & 0xFF;
+    printf("Accessed memory at offset %d (page %d)\n", i, i/4096);
+    // sleep(20); // Sleep a bit to see paging in the kernel logs
+  }
+  
+  // Verify the data was written correctly
+  int errors = 0;
+  for (int i = 0; i < ARRAY_SIZE; i += 4096) {
+    if (large_array[i] != (i & 0xFF)) {
+      printf("Error at index %d: expected %d, got %d\n", 
+             i, i & 0xFF, large_array[i]);
+      errors++;
+    }
+  }
+  
+  if (errors == 0)
+    printf("Sequential access test passed!\n");
+  else
+    printf("Sequential access test failed with %d errors\n", errors);
+}
+
+void test_random_access() {
+  printf("\nTesting random memory access...\n");
+  
+  // Access some random pages to demonstrate non-sequential demand paging
+  int indices[] = {
+    1048576,  // 1MB mark
+    2097152,  // 2MB mark 
+    3145728,  // 3MB mark
+    512000,   // ~0.5MB mark
+    2621440   // ~2.5MB mark
+  };
+  
+  for (int i = 0; i < 5; i++) {
+    int idx = indices[i];
+    large_array[idx] = (idx & 0xFF);
+    printf("Accessed memory at offset %d (page %d)\n", idx, idx/4096);
+    sleep(20); // Sleep a bit to see paging in the kernel logs
+  }
+  
+  // Verify the data
+  int errors = 0;
+  for (int i = 0; i < 5; i++) {
+    int idx = indices[i];
+    if (large_array[idx] != (idx & 0xFF)) {
+      printf("Error at index %d: expected %d, got %d\n", 
+             idx, idx & 0xFF, large_array[idx]);
+      errors++;
+    }
+  }
+  
+  if (errors == 0)
+    printf("Random access test passed!\n");
+  else
+    printf("Random access test failed with %d errors\n", errors);
+}
+
+void test_bss_section() {
+  printf("\nTesting BSS section (should be demand-paged and zero-initialized)...\n");
+  
+  // The large_array is in the BSS section and should be demand-paged
+  // Check that it's properly zero-initialized
+  int errors = 0;
+  for (int i = 10000; i < 20000; i += 1000) {
+    if (large_array[i] != 0) {
+      printf("Error: BSS section not zeroed at index %d (value: %d)\n", 
+             i, large_array[i]);
+      errors++;
+    } else {
+      printf("Verified zero at index %d\n", i);
+    }
+    sleep(10);
+  }
+  
+  if (errors == 0)
+    printf("BSS section test passed!\n");
+  else
+    printf("BSS section test failed with %d errors\n", errors);
+}
+
+int main() {
+  printf("Starting demand paging test...\n");
+  printf("Large array size: %d bytes (%d pages)\n", 
+         ARRAY_SIZE, ARRAY_SIZE/4096);
+  
+  test_bss_section();
+  test_sequential_access();
+  test_random_access();
+  
+  printf("\nAll demand paging tests completed\n");
+  return 0;
+}


### PR DESCRIPTION
#[A3] Demand Paging

## High Level Overview:
- [x] `kernel/exec.c`: Modify `loadseg()` and `exec()` to create invalid PTEs and store file offsets.
    - you’ll need to store metadata (e.g., file offsets) for each virtual page so that the page fault handler can later load the page from the executable file when needed
   
- [x] `kernel/vm.c`: Update `mappages()` to handle these invalid entries.
   - Store metadata (e.g., file offset) in the PTE or in a separate data structure linked to the PTE
   -  For simplicity, let’s assume we add a new flag (e.g., PTE_D for "demand-paged") and store the file offset in the PPN field when the page is invalid.
   - except for essential initial pages (e.g., stack, code entry point).
   - [x] Fix the `uvmcopy` and `walkaddr` implementation to address sys_calls handling. Currently traps are handled as expected. Refactor out the `demand_paging()` into a helper function for reusability within the both.
  
- [x] `kernel/trap.c`, implement a page fault handler (e.g., `handle_pgfault(`) to catch faults caused by invalid PTEs (PTE_V = 0).
- [x] Add a user test. 

